### PR TITLE
Fix docker tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.6/pact-1.88.6-linux-x86_64.tar.gz
           tar xzf pact-1.88.6-linux-x86_64.tar.gz
           echo "$PWD/pact/bin" >> $GITHUB_PATH
-      
+
       - name: Run Tests
         run: |
           gotestsum --junitfile /tmp/test-results/unit-tests.xml -- ./... -coverprofile=/tmp/test-coverage.txt
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run linting
         uses: golangci/golangci-lint-action@v2
-  
+
   acceptance-test:
     name: Acceptance Testing
     runs-on: ubuntu-latest
@@ -113,11 +113,11 @@ jobs:
           docker container create --name temp -v pacts_data:/root hello-world
           docker cp ./pacts/ignored-ignored.json temp:/root/ignored-ignored.json
           docker cp ./pacts/sirius-workflow-sirius.json temp:/root/sirius-workflow-sirius.json
-          
+
       - name: Run pa11y
         run: |
           docker-compose -f docker/docker-compose.ci.yml run --entrypoint="pa11y-ci" puppeteer
-      
+
       - name: Run Lighthouse
         run: |
           docker-compose -f docker/docker-compose.ci.yml run --entrypoint="lhci autorun" puppeteer
@@ -154,7 +154,12 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Extract branch name
-        run: echo BRANCH_NAME=${{ github.head_ref }} >> $GITHUB_ENV
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "push" ]; then
+            echo BRANCH_NAME=main >> $GITHUB_ENV
+          else
+            echo BRANCH_NAME=${{ github.head_ref }} >> $GITHUB_ENV
+          fi
         id: extract_branch
       - uses: unfor19/install-aws-cli-action@v1
 
@@ -185,13 +190,13 @@ jobs:
           role-to-assume: arn:aws:iam::311462405659:role/sirius-actions-ci
           role-duration-seconds: 3600
           role-session-name: GitHubActions
-      
+
       - name: ECR Login
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registries: 311462405659
-      
+
       - name: Push Container
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -201,11 +206,11 @@ jobs:
           docker tag sirius/sirius-workflow:latest $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
           if [ $BRANCH_NAME == "main" ]; then
             # We want all of the tags pushed
-            docker push $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY
+            docker pushh --all-tags $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY
           else
             docker push $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
           fi
-      
+
   push-tags:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
           docker tag sirius/sirius-workflow:latest $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
           if [ $BRANCH_NAME == "main" ]; then
             # We want all of the tags pushed
-            docker pushh --all-tags $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY
+            docker push --all-tags $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY
           else
             docker push $ECR_REGISTRY/$WORKFLOW_ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
           fi
@@ -239,4 +239,3 @@ jobs:
       - name: Trigger Dev Deploy
         shell: bash
         run: curl -u ${{ secrets.JENKINS_API_USER }}:${{ secrets.JENKINS_API_TOKEN }} "https://${{ secrets.JENKINS_URL }}/job/Sirius/job/Deploy_to_Development/build?token=${{ secrets.JENKINS_API_TOKEN_NAME }}&cause=Triggered+by+opg-sirius-workflow"
-


### PR DESCRIPTION
`github.head_ref` is only set on pull request events, so we should handle push events differently. There isn't an alternative variable, but we can only push to the main branch so we know that will be the branch name.

Also push `--all-tags` to ensure both `latest` and the semver tag are pushed on main builds.